### PR TITLE
CIP 68 Royalties - Collaborator Discussion

### DIFF
--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -383,6 +383,18 @@ extra = plutus_data
 royalty_info = #6.121([royalty_recipients, version, extra])
 ```
 
+Example of onchain variable fee calculation:
+```
+; Given a royalty fee of 1.6% (0.016)
+
+; To store this in the royalty datum
+1 / (0.016 / 10) => 625
+
+; To read it back
+10 / 625 => 0.016
+```
+Because the computational complexity of Plutus primitives scales with size, this approach significantly minimizes resource consumption.
+
 To prevent abuse, it is **recommended** that the `royalty NFT` is stored at the script address of a validator that ensures the specified fees are not arbitrarily changed, such as an always-fails validator.
 
 ##### Retrieve metadata as 3rd party

--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -335,7 +335,7 @@ The fourth introduced standard is the `500` Royalty NFT standard with the regist
 
 | asset_name_label            | class        | description                                                          |
 | --------------------------- | ------------ | -------------------------------------------------------------------- |
-| 500                         | NFT          | Royalty NFT locked at a script containing a datum with royalty information |
+| 500                         | NFT          | Royalty NFT stored in a UTxO containing a datum with royalty information |
 
 ##### Class
 
@@ -382,6 +382,8 @@ extra = plutus_data
 
 royalty_info = #6.121([royalty_recipients, version, extra])
 ```
+
+To prevent abuse, it is **recommended** that the `royalty NFT` is stored at the script address of a validator that ensures the specified fees are not arbitrarily changed, such as an always-fails validator.
 
 ##### Retrieve metadata as 3rd party
 

--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -345,10 +345,10 @@ The `royalty token` is an NFT (non-fungible token).
 
 ##### Pattern
 
-The `royalty token` and `reference NFT` **must** have an identical name, preceded by the `asset_name_label` prefix.
+The `royalty token` and `reference NFT` **must** have an identical policy ID. The royalty token's name should be `Royalty`, preceded by the `asset_name_label` prefix.
 
 Example:\
-`royalty token`: `(500)Test123`\
+`royalty token`: `(500)Royalty`\
 `reference NFT`: `(100)Test123`
 
 ##### Metadata
@@ -390,7 +390,7 @@ royalty_info = #6.121([royalty_recipients, version, extra])
 
 A third party has the following NFT `d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc.(222)TestToken` and they want to lookup the royalties. The steps are
 
-1. Construct `royalty NFT` from `user token`: `d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc.(500)TestToken`
+1. Construct `royalty NFT` from `user token`: `d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc.(500)Royalty`
 2. Look up `royalty NFT` and find the output it's locked in.
 3. Get the datum from the output and lookup metadata by going into the first field of constructor 0.
 4. Convert to JSON and encode all string entries to UTF-8 if possible, otherwise leave them in hex.
@@ -399,7 +399,7 @@ A third party has the following NFT `d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5c
 
 We want to bring the royalty metadata of the NFT `d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc.(222)TestToken` in the Plutus validator context. To do this we
 
-1. Construct `royalty NFT` from `user token`: `d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc.(500)TestToken` (off-chain)
+1. Construct `royalty NFT` from `user token`: `d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc.(500)Royalty` (off-chain)
 2. Look up `royalty NFT` and find the output it's locked in. (off-chain)
 3. Reference the output in the transaction. (off-chain)
 4. Verify validity of datum of the referenced output by checking if policy ID of `royalty NFT` and `user token` and their asset names without the `asset_name_label` prefix match. (on-chain)

--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -95,7 +95,7 @@ datum = #6.121([metadata, version, extra])
 
 #### 222 NFT Standard
 
-Besides the necessary standard for the `reference NFT` we're introducing three specific token standards in this CIP. Note that the possibilities are endless here and more standards can be built on top of this CIP for FTs, other NFTs, rich fungible tokens, etc. The first is the `222` NFT standard with the registered `asset_name_label` prefix value
+Besides the necessary standard for the `reference NFT` we're introducing four specific token standards in this CIP. Note that the possibilities are endless here and more standards can be built on top of this CIP for FTs, other NFTs, rich fungible tokens, etc. The first is the `222` NFT standard with the registered `asset_name_label` prefix value
 
 | asset_name_label            | class        | description                                                          |
 | --------------------------- | ------------ | -------------------------------------------------------------------- |
@@ -328,6 +328,81 @@ We want to bring the metadata of the RFT `d5e6bf0500378d4f0da4e8dde6becec7621cd8
 2. Look up `reference NFT` and find the output it's locked in. (off-chain)
 3. Reference the output in the transaction. (off-chain)
 4. Verify validity of datum of the referenced output by checking if policy ID of `reference NFT` and `user token` and their asset names without the `asset_name_label` prefix match. (on-chain)
+
+#### 500 Royalty Standard
+
+The third introduced standard is the `500` Royalty NFT standard with the registered `asset_name_label` prefix value
+
+| asset_name_label            | class        | description                                                          |
+| --------------------------- | ------------ | -------------------------------------------------------------------- |
+| 500                         | NFT          | Royalty NFT locked at a script containing a datum making use of CIP-0027 inner structure             |
+
+
+
+##### Class
+
+The `royalty token` is an NFT (non-fungible token).
+
+##### Pattern
+
+The `royalty token` and `reference NFT` **must** have an identical name, preceded by the `asset_name_label` prefix.
+
+Example:\
+`royalty token`: `(500)Test123`\
+`reference NFT`: `(100)Test123`
+
+##### Metadata
+
+The ideal way to handle the royalty token is to have it under the same `policy id` as the collection. This will make the authentication process smoother and more efficient. However, Nebula allows for specifying a different `policy id` if necessary.\
+The `asset name` **must** be `001f4d70526f79616c7479` (hex encoded), it contains the [CIP-0067](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0067/README.md) label `500`.
+
+The royalty info datum is specified as follows (CDDL):
+
+```cddl
+big_int = int / big_uint / big_nint
+big_uint = #6.2(bounded_bytes)
+big_nint = #6.3(bounded_bytes)
+
+optional_big_int = #6.121([big_int]) / #6.122([])
+
+royalty_recipient = #6.121([
+              address,                    ; definition can be derived from: 
+                                          ; https://github.com/input-output-hk/plutus/blob/master/plutus-ledger-api/src/PlutusLedgerApi/V1/Address.hs#L31
+              int,                        ; variable fee ( calculation: ⌊1 / (fee / 10)⌋ ); integer division with precision 10
+              optional_big_int,           ; min fee (absolute value in lovelace)
+              optional_big_int,           ; max fee (absolute value in lovelace)
+            ])
+
+royalty_recipients = [ * royalty_recipient ]
+
+; version is of type int, we start with version 1
+version = 1  
+
+; Custom user defined plutus data.
+; Setting data is optional, but the field is required
+; and needs to be at least Unit/Void: #6.121([])
+extra = plutus_data
+
+royalty_info = #6.121([royalty_recipients, version, extra])
+```
+
+##### Retrieve metadata as 3rd party
+
+A third party has the following NFT `d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc.(222)TestToken` and they want to lookup the royalties. The steps are
+
+1. Construct `royalty NFT` from `user token`: `d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc.(500)TestToken`
+2. Look up `royalty NFT` and find the output it's locked in.
+3. Get the datum from the output and lookup metadata by going into the first field of constructor 0.
+4. Convert to JSON and encode all string entries to UTF-8 if possible, otherwise leave them in hex.
+
+##### Retrieve metadata from a Plutus validator
+
+We want to bring the royalty metadata of the NFT `d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc.(222)TestToken` in the Plutus validator context. To do this we
+
+1. Construct `royalty NFT` from `user token`: `d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc.(500)TestToken` (off-chain)
+2. Look up `royalty NFT` and find the output it's locked in. (off-chain)
+3. Reference the output in the transaction. (off-chain)
+4. Verify validity of datum of the referenced output by checking if policy ID of `royalty NFT` and `user token` and their asset names without the `asset_name_label` prefix match. (on-chain)
 
 ## Rationale
 

--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -343,7 +343,7 @@ The `royalty NFT` is an NFT (non-fungible token).
 
 ##### Pattern
 
-The ideal way to handle the `royalty NFT` is to have it under the same `policy id` as the collection. This will make the authentication process smoother and more efficient. However, a different `policy id` may be specified if necessary.
+The `royalty NFT` **must** have an identical `policy id` as the collection.
 
 The `asset name` **must** be `001f4d70526f79616c7479` (hex encoded), it contains the [CIP-0067](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0067/README.md) label `500` followed by the word "Royalty".
 

--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -331,11 +331,11 @@ We want to bring the metadata of the RFT `d5e6bf0500378d4f0da4e8dde6becec7621cd8
 
 #### 500 Royalty Standard
 
-The third introduced standard is the `500` Royalty NFT standard with the registered `asset_name_label` prefix value
+The fourth introduced standard is the `500` Royalty NFT standard with the registered `asset_name_label` prefix value
 
 | asset_name_label            | class        | description                                                          |
 | --------------------------- | ------------ | -------------------------------------------------------------------- |
-| 500                         | NFT          | Royalty NFT locked at a script containing a datum making use of CIP-0027 inner structure             |
+| 500                         | NFT          | Royalty NFT locked at a script containing a datum with royalty information |
 
 
 

--- a/CIP-0068/README.md
+++ b/CIP-0068/README.md
@@ -337,24 +337,21 @@ The fourth introduced standard is the `500` Royalty NFT standard with the regist
 | --------------------------- | ------------ | -------------------------------------------------------------------- |
 | 500                         | NFT          | Royalty NFT locked at a script containing a datum with royalty information |
 
-
-
 ##### Class
 
-The `royalty token` is an NFT (non-fungible token).
+The `royalty NFT` is an NFT (non-fungible token).
 
 ##### Pattern
 
-The `royalty token` and `reference NFT` **must** have an identical policy ID. The royalty token's name should be `Royalty`, preceded by the `asset_name_label` prefix.
+The ideal way to handle the `royalty NFT` is to have it under the same `policy id` as the collection. This will make the authentication process smoother and more efficient. However, a different `policy id` may be specified if necessary.
+
+The `asset name` **must** be `001f4d70526f79616c7479` (hex encoded), it contains the [CIP-0067](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0067/README.md) label `500` followed by the word "Royalty".
 
 Example:\
-`royalty token`: `(500)Royalty`\
+`royalty NFT`: `(500)Royalty`\
 `reference NFT`: `(100)Test123`
 
 ##### Metadata
-
-The ideal way to handle the royalty token is to have it under the same `policy id` as the collection. This will make the authentication process smoother and more efficient. However, Nebula allows for specifying a different `policy id` if necessary.\
-The `asset name` **must** be `001f4d70526f79616c7479` (hex encoded), it contains the [CIP-0067](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0067/README.md) label `500`.
 
 The royalty info datum is specified as follows (CDDL):
 


### PR DESCRIPTION
This thread is intended to gather input from developers who are already working on CIP 68-based royalty implementations or have similar vested interest, to make sure we consider all existing use cases before submitting the PR to the CF repository for general review. Interested in any & all input at this point.

The specification is based on [the royalty specification in Nebula](https://github.com/spacebudz/nebula/tree/main#royalty-info-specification), with a couple key departures:

1. The royalty token is recommended to be locked at a script address, rather than stored in the user's wallet. This encourages projects to guarantee royalties won't change by sending their royalties to an always-fails (or similar) script address, but still allows for creative royalty schemes and minimizes disruption to existing projects.
2. The policyId of the royalty NFT **must** match that of the reference NFT. This enables lookups based on the user token in the same way as is done for the other tokens specified in CIP 68.

The specification here is made to be as minimal as possible. This is done with expediency in mind and the expectation that additional changes to the specification may be made in the future. The sooner we have a standard established, the sooner we can make use of it. Rather than attempting to anticipate all use cases, we specify with forward-compatibility in mind.

If you're interested in Ikigai's internal discussion that preceded this, check out #1.